### PR TITLE
Extend Technology and TechnologyCollection

### DIFF
--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -162,7 +162,6 @@ note left of SourceCollection::to_dataframe
 end note
 
 class Datapackage {
-  - name: str
   - path: Path
   - technologies: TechnologyCollection
   - sources: SourceCollection

--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -169,7 +169,6 @@ note left of SourceCollection::to_dataframe
 end note
 
 class Datapackage {
-  - path: Path
   - technologies: TechnologyCollection
   - sources: SourceCollection
   - // potentially other Collections in the future
@@ -188,23 +187,12 @@ note top of Datapackage
   Please note that the "sources" field is built in the background from "technologies"
 end note
 
-note right of Datapackage::name
-  Currently we use "source" as a reference to pre-packaged data and for a column in "technologies.csv".
-  The Datapackage.name would substitute for referencing to pre-packaged data, e.g. "example01" would be
-  a packaged data included with `technologydata`. It is meant to be independent of the "TechnologyCollection" or its members.
-end note
-
 note right of Datapackage::technologies
   Derived from the TechnologyCollection.
 end note
 
 note right of Datapackage::sources
   Built in the background with the get_source_collection() method, which derives it from all Source objects that are related to the TechnologyCollection (i.e., all sources referenced by technologies and their parameters).
-end note
-
-note right of Datapackage::to_datapackage
-  Exports all member Source and TechnologyCollection to a folder following the datapackage
-  specification, including the schema .json files and the .csv files.
 end note
 
 Parameter --> SourceCollection : sources

--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -173,7 +173,7 @@ class Datapackage {
   - technologies: TechnologyCollection
   - sources: SourceCollection
   - // potentially other Collections in the future
-  + to_datapackage()
+  + to_csv()
   + from_json()
   + to_json()
   + get_source_collection()

--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -42,6 +42,7 @@ class Parameter {
   - provenance: str
   - note: str
   - sources: SourceCollection
+  + from_dict(): Parameter
 }
 
 Parameter --> UnitValue : quantity
@@ -72,6 +73,7 @@ class Technology {
   - output-hydrogen: Parameter
   - output-electricity: Parameter
 
+  + from_dict(): Technology
   + adjust_currency(): Technology               // or inplace
   + adjust_region(): Technology                 // or inplace
   + adjust_scale(): Technology                  // or inplace
@@ -116,6 +118,11 @@ end note
 class TechnologyCollection {
   - technologies: Iterable<Technology>
   + get(**criteria): Technology | TechnologyCollection | None
+  + from_dict(): TechnologyCollection
+  + to_json(): str
+  + to_csv(): str
+  + to_dataframe(): pd.DataFrame
+  + from_json(): TechnologyCollection
   + create_projection(): TechnologyCollection
   ' TODO: Think about more methods here
 }

--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -10,7 +10,7 @@ class UnitValue {
 }
 
 note left of UnitValue::unit
-  Unit should be able to accomodate any unit of measurement,
+  Unit should be able to accommodate any unit of measurement,
   currencies+years, LHVs and different energy carriers.
   e.g. EUR_2020, kWh_electricity, kWh_hydrogen_LHV
 end note
@@ -20,8 +20,8 @@ class Source {
   - authors: str
   - url: str
   - url_archive: str
-  - urldate: str
-  - urldate_archive: str
+  - url_date: str
+  - url_date_archive: str
 
   + ensure_in_wayback()
   + store_in_wayback()
@@ -149,12 +149,12 @@ note left of SourceCollection::retrieve_all_from_wayback
   and stores the files locally.
 end note
 
-note left of SourceCollection::to_csv
-  Export the source collection into a csv file.
-end note
-
 note left of SourceCollection::to_json
   Export the source collection into a json file.
+end note
+
+note left of SourceCollection::to_csv
+  Export the source collection into a csv file.
 end note
 
 note left of SourceCollection::to_dataframe

--- a/technologydata/__init__.py
+++ b/technologydata/__init__.py
@@ -8,17 +8,19 @@ from technologydata.parameter import Parameter
 from technologydata.source import Source
 from technologydata.source_collection import SourceCollection
 from technologydata.technology import Technology
+from technologydata.technology_collection import TechnologyCollection
 from technologydata.unit_value import UnitValue
 from technologydata.utils.commons import Commons, DateFormatEnum, FileExtensionEnum
 
 __all__ = [
     "Commons",
     "DateFormatEnum",
+    "DataPackage",
     "FileExtensionEnum",
-    "UnitValue",
-    "Technology",
     "Parameter",
     "Source",
     "SourceCollection",
-    "DataPackage",
+    "Technology",
+    "TechnologyCollection",
+    "UnitValue",
 ]

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -155,31 +155,3 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
         if self.sources is not None:
             sources_path = pathlib.Path(folder_path, "sources.csv")
             self.sources.to_csv(path_or_buf=sources_path)
-
-    def to_datapackage(
-        self, path_to_folder: pathlib.Path, output_format: str = "json"
-    ) -> None:
-        """
-        Export the DataPackage to the specified format and save to the given folder.
-
-        Parameters
-        ----------
-        path_to_folder : pathlib.Path
-            The directory path where the data package will be saved.
-        output_format : str, optional
-            The format to export the data package ('json' or 'csv'). Default is 'json'.
-
-        Raises
-        ------
-        ValueError
-            If an unsupported output format is specified.
-
-        """
-        if output_format == "json":
-            self.to_json(path_to_folder)
-        elif output_format == "csv":
-            self.to_csv(path_to_folder)
-        else:
-            raise ValueError(
-                f"Unsupported output format: {output_format}. Use 'json' or 'csv'."
-            )

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -28,8 +28,6 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
 
     Parameters
     ----------
-    path : pathlib.Path
-        The path to the data package.
     technologies : Optional[TechnologyCollection]
         List of Technology objects.
     sources : Optional[SourceCollection]
@@ -37,8 +35,6 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
 
     Attributes
     ----------
-    path : pathlib.Path
-        The path to the data package.
     technologies : Optional[TechnologyCollection]
         List of Technology objects.
     sources : Optional[SourceCollection]
@@ -46,9 +42,6 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
 
     """
 
-    path: pathlib.Path = pydantic.Field(
-        ..., description="The path to the data package."
-    )
     technologies: TechnologyCollection | None = pydantic.Field(
         None, description="List of Technology objects."
     )

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -16,8 +16,7 @@ import pathlib
 import pydantic
 
 from technologydata.source_collection import SourceCollection
-
-# from technologydata.technology_collection import TechnologyCollection
+from technologydata.technology_collection import TechnologyCollection
 
 
 # TODO complete class
@@ -28,21 +27,56 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
     Parameters
     ----------
     name : str
-        The short-name code of the source
-    technologies : List[Technology]
+        The short-name code of the data package.
+    path : pathlib.Path
+        The path to the data package.
+    technologies : TechnologyCollection
         List of Technology objects.
+    sources : SourceCollection
+        List of Source objects.
 
     Attributes
     ----------
-    technologies : List[Technology]
+    name : str
+        The short-name code of the data package.
+    path : pathlib.Path
+        The path to the data package.
+    technologies : TechnologyCollection
         List of Technology objects.
+    sources : SourceCollection
+        List of Source objects.
 
     """
 
-    name: str
-    path: pathlib.Path
-    # technologies: TechnologyCollection
-    sources: SourceCollection
+    name: str = pydantic.Field(
+        ..., description="The short-name code of the data package."
+    )
+    path: pathlib.Path = pydantic.Field(
+        ..., description="The path to the data package."
+    )
+    technologies: TechnologyCollection = pydantic.Field(
+        ..., description="List of Technology objects."
+    )
+    sources: SourceCollection | None = pydantic.Field(
+        None, description="List of Source objects."
+    )
+
+    def get_source_collection(self) -> None:
+        """
+        Get the SourceCollection associated with this DataPackage from the TechnologyCollection.
+
+        Returns
+        -------
+        SourceCollection
+            The SourceCollection instance.
+
+        """
+        sources_set = set()
+        if self.sources is None:
+            for technology in self.technologies:
+                for parameter in technology.parameters.values():
+                    sources_set.update(parameter.sources)
+        self.sources = sources_set
 
     # @classmethod
     # def from_json(cls, path: pathlib.Path) -> technologydata.DataPackage:

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -32,7 +32,7 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
         The path to the data package.
     technologies : TechnologyCollection
         List of Technology objects.
-    sources : SourceCollection
+    sources : Optional[SourceCollection]
         List of Source objects.
 
     Attributes
@@ -43,7 +43,7 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
         The path to the data package.
     technologies : TechnologyCollection
         List of Technology objects.
-    sources : SourceCollection
+    sources : Optional[SourceCollection]
         List of Source objects.
 
     """

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -159,6 +159,22 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
     def to_datapackage(
         self, path_to_folder: pathlib.Path, output_format: str = "json"
     ) -> None:
+        """
+        Export the DataPackage to the specified format and save to the given folder.
+
+        Parameters
+        ----------
+        path_to_folder : pathlib.Path
+            The directory path where the data package will be saved.
+        output_format : str, optional
+            The format to export the data package ('json' or 'csv'). Default is 'json'.
+
+        Raises
+        ------
+        ValueError
+            If an unsupported output format is specified.
+
+        """
         if output_format == "json":
             self.to_json(path_to_folder)
         elif output_format == "csv":

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -75,8 +75,9 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
         if self.sources is None:
             for technology in self.technologies:
                 for parameter in technology.parameters.values():
-                    sources_set.update(parameter.sources)
-        self.sources = sources_set
+                    for source in parameter.sources:
+                        sources_set.add(source)
+        self.sources = SourceCollection(sources=list(sources_set))
 
     # @classmethod
     # def from_json(cls, path: pathlib.Path) -> technologydata.DataPackage:

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -11,6 +11,7 @@ Examples
 
 """
 
+import logging
 import pathlib
 
 import pydantic
@@ -18,44 +19,38 @@ import pydantic
 from technologydata.source_collection import SourceCollection
 from technologydata.technology_collection import TechnologyCollection
 
+logger = logging.getLogger(__name__)
 
-# TODO complete class
+
 class DataPackage(pydantic.BaseModel):  # type: ignore
     """
     Container for a collection of Technology objects and/or Source objects, with batch operations and loading utilities.
 
     Parameters
     ----------
-    name : str
-        The short-name code of the data package.
     path : pathlib.Path
         The path to the data package.
-    technologies : TechnologyCollection
+    technologies : Optional[TechnologyCollection]
         List of Technology objects.
     sources : Optional[SourceCollection]
         List of Source objects.
 
     Attributes
     ----------
-    name : str
-        The short-name code of the data package.
     path : pathlib.Path
         The path to the data package.
-    technologies : TechnologyCollection
+    technologies : Optional[TechnologyCollection]
         List of Technology objects.
     sources : Optional[SourceCollection]
         List of Source objects.
 
     """
 
-    name: str = pydantic.Field(
-        ..., description="The short-name code of the data package."
-    )
     path: pathlib.Path = pydantic.Field(
         ..., description="The path to the data package."
     )
-    technologies: TechnologyCollection = pydantic.Field(
-        ..., description="List of Technology objects."
+    technologies: TechnologyCollection | None = pydantic.Field(
+        None, description="List of Technology objects."
     )
     sources: SourceCollection | None = pydantic.Field(
         None, description="List of Source objects."
@@ -73,49 +68,102 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
         """
         sources_set = set()
         if self.sources is None:
-            for technology in self.technologies:
-                for parameter in technology.parameters.values():
-                    for source in parameter.sources:
-                        sources_set.add(source)
+            if self.technologies is not None:
+                for technology in self.technologies:
+                    for parameter in technology.parameters.values():
+                        for source in parameter.sources:
+                            sources_set.add(source)
+            else:
+                raise ValueError(
+                    "No technologies available to extract a sources collection from."
+                )
+        else:
+            logger.info("The data package already has a sources collection.")
         self.sources = SourceCollection(sources=list(sources_set))
 
-    # @classmethod
-    # def from_json(cls, path: pathlib.Path) -> technologydata.DataPackage:
-    #     """
-    #     Load a DataPackage from a JSON file.
-    #
-    #     Parameters
-    #     ----------
-    #     path : Path
-    #         Path to the JSON file.
-    #
-    #     Returns
-    #     -------
-    #     DataPackage
-    #         The loaded DataPackage instance.
-    #
-    #     """
-    #     with open(path) as f:
-    #         data = json.load(f)
-    #     techs = technologydata.TechnologyCollection(
-    #         [technologydata.Technology(**t) for t in data.get("technologies", [])]
-    #     )
-    #     # TODO: redo this part once an example JSON is available
-    #     techs = technologydata.TechnologyCollection(
-    #         [technologydata.Technology(**t) for t in data.get("technologies", [])]
-    #     )
-    #     # You should also handle 'name', 'sources', etc. as needed
-    #     return cls(
-    #         name=data.get("name", ""),
-    #         path=path,
-    #         technologies=techs,
-    #         sources=technologydata.SourceCollection(data.get("sources", [])),
-    #     )
-    #
-    # @classmethod
-    # def to_json(cls, path: pathlib.Path) -> None:
-    #     pass
-    #
-    # @classmethod
-    # def to_datapackage(cls, path: pathlib.Path) -> None:
-    #     pass
+    @classmethod
+    def from_json(cls, path_to_folder: pathlib.Path | str) -> "DataPackage":
+        """
+        Load a DataPackage from a JSON file.
+
+        Parameters
+        ----------
+        path_to_folder : pathlib.Path or str
+            Path to the data package folder.
+
+        Returns
+        -------
+        DataPackage
+            The loaded DataPackage instance.
+
+        """
+        # Load technologies
+        technologies_path = pathlib.Path(path_to_folder, "technologies.json")
+        technologies = TechnologyCollection.from_json(technologies_path)
+
+        # Create DataPackage instance
+        data_package = cls(
+            path=path_to_folder,
+            technologies=technologies,
+        )
+
+        # Generate sources collection from technologies if sources is None
+        data_package.get_source_collection()
+
+        return data_package
+
+    def to_json(self, folder_path: pathlib.Path) -> None:
+        """
+        Export the Datapackage to JSON files.
+
+        The files are:
+         - the 'technologies' attribute is exported to technologies.json, together with the corresponding data schema
+         - the 'sources' attribute is exported to sources.json, together with the corresponding data schema
+
+        Parameters
+        ----------
+        folder_path : pathlib.Path
+            The path to the folder where the JSON files are created
+
+        """
+        if self.technologies is not None:
+            technologies_path = pathlib.Path(folder_path, "technologies.json")
+            self.technologies.to_json(technologies_path)
+
+        if self.sources is not None:
+            sources_path = pathlib.Path(folder_path, "sources.json")
+            self.sources.to_json(sources_path)
+
+    def to_csv(self, folder_path: pathlib.Path) -> None:
+        """
+        Export the Datapackage to CSV files.
+
+        The files are:
+         - the 'technologies' attribute is exported to technologies.csv
+         - the 'sources' attribute is exported to sources.csv
+
+        Parameters
+        ----------
+        folder_path : pathlib.Path
+            The path to the folder where the CSV files are created
+
+        """
+        if self.technologies is not None:
+            technologies_path = pathlib.Path(folder_path, "technologies.csv")
+            self.technologies.to_csv(path_or_buf=technologies_path)
+
+        if self.sources is not None:
+            sources_path = pathlib.Path(folder_path, "sources.csv")
+            self.sources.to_csv(path_or_buf=sources_path)
+
+    def to_datapackage(
+        self, path_to_folder: pathlib.Path, output_format: str = "json"
+    ) -> None:
+        if output_format == "json":
+            self.to_json(path_to_folder)
+        elif output_format == "csv":
+            self.to_csv(path_to_folder)
+        else:
+            raise ValueError(
+                f"Unsupported output format: {output_format}. Use 'json' or 'csv'."
+            )

--- a/technologydata/datapackage.py
+++ b/technologydata/datapackage.py
@@ -13,6 +13,7 @@ Examples
 
 import logging
 import pathlib
+import typing
 
 import pydantic
 
@@ -26,13 +27,6 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
     """
     Container for a collection of Technology objects and/or Source objects, with batch operations and loading utilities.
 
-    Parameters
-    ----------
-    technologies : Optional[TechnologyCollection]
-        List of Technology objects.
-    sources : Optional[SourceCollection]
-        List of Source objects.
-
     Attributes
     ----------
     technologies : Optional[TechnologyCollection]
@@ -42,12 +36,13 @@ class DataPackage(pydantic.BaseModel):  # type: ignore
 
     """
 
-    technologies: TechnologyCollection | None = pydantic.Field(
-        None, description="List of Technology objects."
-    )
-    sources: SourceCollection | None = pydantic.Field(
-        None, description="List of Source objects."
-    )
+    technologies: typing.Annotated[
+        TechnologyCollection | None,
+        pydantic.Field(description="List of Technology objects."),
+    ] = None
+    sources: typing.Annotated[
+        SourceCollection | None, pydantic.Field(description="List of Source objects.")
+    ] = None
 
     def get_source_collection(self) -> None:
         """

--- a/technologydata/parameter.py
+++ b/technologydata/parameter.py
@@ -28,17 +28,6 @@ class Parameter(pydantic.BaseModel):  # type: ignore
     """
     Encapsulate a value with its unit, provenance, notes, and sources.
 
-    Parameters
-    ----------
-    quantity : UnitValue
-        The value and its unit.
-    provenance : Optional[str]
-        Description of the data's provenance.
-    note : Optional[str]
-        Additional notes about the parameter.
-    sources : SourceCollection
-        One or more sources for the parameter.
-
     Attributes
     ----------
     quantity : UnitValue
@@ -52,12 +41,18 @@ class Parameter(pydantic.BaseModel):  # type: ignore
 
     """
 
-    quantity: UnitValue = pydantic.Field(..., description="The value and its unit.")
-    provenance: str | None = pydantic.Field(None, description="Data provenance.")
-    note: str | None = pydantic.Field(None, description="Additional notes.")
-    sources: SourceCollection = pydantic.Field(
-        ..., description="Collection of Sources."
-    )
+    quantity: typing.Annotated[
+        UnitValue, pydantic.Field(description="The value and its unit.")
+    ]
+    provenance: typing.Annotated[
+        str | None, pydantic.Field(description="Data provenance.")
+    ] = None
+    note: typing.Annotated[
+        str | None, pydantic.Field(description="Additional notes.")
+    ] = None
+    sources: typing.Annotated[
+        SourceCollection, pydantic.Field(description="Collection of Sources.")
+    ]
 
     @property
     def value(self) -> float:

--- a/technologydata/parameter.py
+++ b/technologydata/parameter.py
@@ -110,7 +110,7 @@ class Parameter(pydantic.BaseModel):  # type: ignore
         """
         # Convert sources list into SourceCollection
         sources_data = data.get("sources", [])
-        sources = SourceCollection.from_json(sources_data)
+        sources = SourceCollection.from_json(from_str=sources_data)
         return cls(
             quantity=UnitValue.model_validate(data["quantity"]),
             provenance=data.get("provenance"),

--- a/technologydata/parameter.py
+++ b/technologydata/parameter.py
@@ -82,3 +82,15 @@ class Parameter(pydantic.BaseModel):  # type: ignore
 
         """
         return self.quantity.unit
+
+    @classmethod
+    def from_dict(cls, data):
+        # Convert sources list into SourceCollection
+        sources_data = data.get("sources", [])
+        sources = SourceCollection.from_json(sources_data)
+        return cls(
+            quantity=UnitValue.parse_obj(data["quantity"]),
+            provenance=data.get("provenance"),
+            note=data.get("note"),
+            sources=sources,
+        )

--- a/technologydata/parameter.py
+++ b/technologydata/parameter.py
@@ -15,6 +15,8 @@ Examples
 
 """
 
+import typing
+
 import pydantic
 
 from technologydata.source_collection import SourceCollection
@@ -84,12 +86,38 @@ class Parameter(pydantic.BaseModel):  # type: ignore
         return self.quantity.unit
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: dict[str, typing.Any]) -> "Parameter":
+        """
+        Create an instance of the class from a dictionary.
+
+        Parameters
+        ----------
+        cls : type
+            The class to instantiate.
+        data : dict
+            A dictionary containing the data to initialize the class instance.
+            Expected keys include:
+                - "quantity" (dict): A dictionary representing a UnitValue, parsed via `UnitValue.parse_obj()`.
+                - "provenance" (str or None): Optional provenance information.
+                - "note" (str or None): Optional notes.
+                - "sources" (list): A list of source data dictionaries, to be converted into a SourceCollection.
+
+        Returns
+        -------
+        instance : cls
+            An instance of the class initialized with the provided data.
+
+        Notes
+        -----
+        This method converts the "sources" list into a `SourceCollection` using `SourceCollection.from_json()`.
+        The "quantity" field is parsed into a `UnitValue` object using `UnitValue.parse_obj()`.
+
+        """
         # Convert sources list into SourceCollection
         sources_data = data.get("sources", [])
         sources = SourceCollection.from_json(sources_data)
         return cls(
-            quantity=UnitValue.parse_obj(data["quantity"]),
+            quantity=UnitValue.model_validate(data["quantity"]),
             provenance=data.get("provenance"),
             note=data.get("note"),
             sources=sources,

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -73,6 +73,27 @@ class Source(pydantic.BaseModel):  # type: ignore
         None, description="Date the URL was archived."
     )
 
+    def __str__(self) -> str:
+        """
+        Return a string representation of the Source, including all available attributes.
+
+        Returns
+        -------
+        str
+            A string detailing the source's information.
+
+        """
+        parts = [f"Title: '{self.title}'", f"Authors: '{self.authors}'"]
+        if self.url:
+            parts.append(f"URL: '{self.url}'")
+        if self.url_archive:
+            parts.append(f"Archived URL: '{self.url_archive}'")
+        if self.url_date:
+            parts.append(f"URL Date: '{self.url_date}'")
+        if self.url_date_archive:
+            parts.append(f"URL Date Archive: '{self.url_date_archive}'")
+        return ", ".join(parts)
+
     def ensure_in_wayback(self) -> None:
         """
         Ensure that the source URL is archived in the Wayback Machine.

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -110,16 +110,11 @@ class Source(pydantic.BaseModel):  # type: ignore
             The hash value of the Source instance.
 
         """
-        return hash(
-            (
-                self.title,
-                self.authors,
-                self.url,
-                self.url_archive,
-                self.url_date,
-                self.url_date_archive,
-            )
+        # Retrieve all attribute values dynamically
+        attribute_values = tuple(
+            getattr(self, field) for field in self.__class__.model_fields.keys()
         )
+        return hash(attribute_values)
 
     def __str__(self) -> str:
         """

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -93,9 +93,8 @@ class Source(pydantic.BaseModel):  # type: ignore
         for field in self.__class__.model_fields.keys():
             value_self = getattr(self, field)
             value_other = getattr(other, field)
-            if value_self is not None and value_other is not None:
-                if value_self != value_other:
-                    return False
+            if value_self != value_other:
+                return False
         return True
 
     def __hash__(self) -> int:

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -73,6 +73,66 @@ class Source(pydantic.BaseModel):  # type: ignore
         None, description="Date the URL was archived."
     )
 
+    def __eq__(self, other: object) -> bool:
+        """
+        Check for equality with another Source object based on non-None attributes.
+
+        Compares all attributes of the current instance with those of the other object.
+        Only compares attributes that are not None in both instances.
+
+        Parameters
+        ----------
+        other : object
+            The object to compare with. Expected to be an instance of Source.
+
+        Returns
+        -------
+        bool
+            True if all non-None attributes are equal between self and other, False otherwise.
+            Returns False if other is not a Source instance.
+
+        Notes
+        -----
+        This method considers only attributes that are not None in both objects.
+        If an attribute is None in either object, it is ignored in the comparison.
+
+        """
+        if not isinstance(other, Source):
+            logger.error("The object is not a Source instance.")
+            return False
+
+        for field in self.__class__.model_fields.keys():
+            value_self = getattr(self, field)
+            value_other = getattr(other, field)
+            if value_self is not None and value_other is not None:
+                if value_self != value_other:
+                    return False
+        return True
+
+    def __hash__(self) -> int:
+        """
+        Return a hash value for the Source instance based on all attributes.
+
+        This method computes a combined hash of the instance's attributes to
+        uniquely identify the object in hash-based collections such as sets and dictionaries.
+
+        Returns
+        -------
+        int
+            The hash value of the Source instance.
+
+        """
+        return hash(
+            (
+                self.title,
+                self.authors,
+                self.url,
+                self.url_archive,
+                self.url_date,
+                self.url_date_archive,
+            )
+        )
+
     def __str__(self) -> str:
         """
         Return a string representation of the Source, including all available attributes.

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -30,21 +30,6 @@ class Source(pydantic.BaseModel):  # type: ignore
     """
     Represent a data source, including bibliographic and web information.
 
-    Parameters
-    ----------
-    title : str
-        Title of the source.
-    authors : str
-        Authors of the source.
-    url : Optional[str]
-        URL of the source.
-    url_archive : Optional[str]
-        Archived URL (e.g., from the Wayback Machine).
-    url_date : Optional[str]
-        Date the URL was accessed.
-    url_date_archive : Optional[str]
-        Date the URL was archived.
-
     Attributes
     ----------
     title : str
@@ -62,16 +47,20 @@ class Source(pydantic.BaseModel):  # type: ignore
 
     """
 
-    title: str = pydantic.Field(..., description="Title of the source.")
-    authors: str = pydantic.Field(..., description="Authors of the source.")
-    url: str | None = pydantic.Field(None, description="URL of the source.")
-    url_archive: str | None = pydantic.Field(None, description="Archived URL.")
-    url_date: str | None = pydantic.Field(
-        None, description="Date the URL was accessed."
-    )
-    url_date_archive: str | None = pydantic.Field(
-        None, description="Date the URL was archived."
-    )
+    title: typing.Annotated[str, pydantic.Field(description="Title of the source.")]
+    authors: typing.Annotated[str, pydantic.Field(description="Authors of the source.")]
+    url: typing.Annotated[
+        str | None, pydantic.Field(description="URL of the source.")
+    ] = None
+    url_archive: typing.Annotated[
+        str | None, pydantic.Field(description="Archived URL.")
+    ] = None
+    url_date: typing.Annotated[
+        str | None, pydantic.Field(description="Date the URL was accessed.")
+    ] = None
+    url_date_archive: typing.Annotated[
+        str | None, pydantic.Field(description="Date the URL was archived.")
+    ] = None
 
     def __eq__(self, other: object) -> bool:
         """

--- a/technologydata/source.py
+++ b/technologydata/source.py
@@ -83,15 +83,15 @@ class Source(pydantic.BaseModel):  # type: ignore
             A string detailing the source's information.
 
         """
-        parts = [f"Title: '{self.title}'", f"Authors: '{self.authors}'"]
+        parts = [f"'{self.authors}': '{self.title}'"]
         if self.url:
-            parts.append(f"URL: '{self.url}'")
-        if self.url_archive:
-            parts.append(f"Archived URL: '{self.url_archive}'")
+            parts.append(f"from url '{self.url}'")
         if self.url_date:
-            parts.append(f"URL Date: '{self.url_date}'")
+            parts.append(f"last accessed on '{self.url_date}'")
+        if self.url_archive:
+            parts.append(f"archived at '{self.url_archive}'")
         if self.url_date_archive:
-            parts.append(f"URL Date Archive: '{self.url_date_archive}'")
+            parts.append(f"on '{self.url_date_archive}'.")
         return ", ".join(parts)
 
     def ensure_in_wayback(self) -> None:

--- a/technologydata/source_collection.py
+++ b/technologydata/source_collection.py
@@ -20,11 +20,6 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
     """
     Represent a collection of sources.
 
-    Parameters
-    ----------
-    sources : List[Source]
-        List of Source objects.
-
     Attributes
     ----------
     sources : List[Source]
@@ -32,7 +27,9 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
 
     """
 
-    sources: list[Source] = pydantic.Field(..., description="List of Source objects.")
+    sources: typing.Annotated[
+        list[Source], pydantic.Field(description="List of Source objects.")
+    ]
 
     def __iter__(self) -> typing.Iterator["Source"]:
         """

--- a/technologydata/source_collection.py
+++ b/technologydata/source_collection.py
@@ -180,7 +180,7 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
             jsonfile.write(json_data)
 
     @classmethod
-    def from_json(cls, file_path: pathlib.Path | str) -> "SourceCollection":
+    def from_json(cls, file_path: pathlib.Path | str | list) -> "SourceCollection":
         """
         Import the SourceCollection from a JSON file.
 
@@ -192,8 +192,13 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
         """
         if isinstance(file_path, pathlib.Path | str):
             file_path = pathlib.Path(file_path)
+            with open(file_path, encoding="utf-8") as jsonfile:
+                json_data = json.load(jsonfile)
+        elif isinstance(file_path, list):
+            # If a list is provided, assume it contains dictionaries representing sources
+            json_data = {"sources": [Source(**source) for source in file_path]}
         else:
-            raise TypeError("file_path must be a pathlib.Path or str")
-        with open(file_path, encoding="utf-8") as jsonfile:
-            json_data = json.load(jsonfile)
+            raise TypeError(
+                f"file_path must be a pathlib.Path or str. Got instead {type(file_path)}"
+            )
         return cls(**json_data)

--- a/technologydata/source_collection.py
+++ b/technologydata/source_collection.py
@@ -8,6 +8,7 @@ import csv
 import json
 import pathlib
 import re
+import typing
 
 import pandas
 import pydantic
@@ -32,6 +33,19 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
     """
 
     sources: list[Source] = pydantic.Field(..., description="List of Source objects.")
+
+    def __str__(self) -> str:
+        """
+        Return a string representation of the SourceCollection.
+
+        Returns
+        -------
+        str
+            A string representation of the SourceCollection, showing the number of sources.
+
+        """
+        sources_str = ", ".join(str(source) for source in self.sources)
+        return f"SourceCollection with {len(self.sources)} sources: {sources_str}"
 
     def get(self, title: str, authors: str) -> "SourceCollection":
         """
@@ -180,13 +194,15 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
             jsonfile.write(json_data)
 
     @classmethod
-    def from_json(cls, file_path: pathlib.Path | str | list) -> "SourceCollection":
+    def from_json(
+        cls, file_path: pathlib.Path | str | list[dict[str, typing.Any]]
+    ) -> "SourceCollection":
         """
         Import the SourceCollection from a JSON file.
 
         Parameters
         ----------
-        file_path : pathlib.Path
+        file_path : pathlib.Path | str | list
             The path to the JSON file to be imported.
 
         """

--- a/technologydata/source_collection.py
+++ b/technologydata/source_collection.py
@@ -34,6 +34,30 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
 
     sources: list[Source] = pydantic.Field(..., description="List of Source objects.")
 
+    def __iter__(self) -> typing.Iterator["Source"]:
+        """
+        Return an iterator over the list of Source objects.
+
+        Returns
+        -------
+        Iterator[Source]
+            An iterator over the Source objects contained in the collection.
+
+        """
+        return iter(self.sources)
+
+    def __len__(self) -> int:
+        """
+        Return the number of sources in this collection.
+
+        Returns
+        -------
+        int
+            The number of Source objects in the sources list.
+
+        """
+        return len(self.sources)
+
     def __str__(self) -> str:
         """
         Return a string representation of the SourceCollection.
@@ -79,18 +103,6 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
             ]
 
         return SourceCollection(sources=filtered_sources)
-
-    def __len__(self) -> int:
-        """
-        Return the number of sources in this collection.
-
-        Returns
-        -------
-        int
-            The number of Source objects in the sources list.
-
-        """
-        return len(self.sources)
 
     def retrieve_all_from_wayback(
         self, download_directory: pathlib.Path

--- a/technologydata/technology.py
+++ b/technologydata/technology.py
@@ -180,3 +180,18 @@ class Technology(pydantic.BaseModel):  # type: ignore
         """
         # Placeholder: implement scaling logic
         return self
+
+    @classmethod
+    def from_dict(cls, data):
+        # Process parameters
+        params = {}
+        for key, param_data in data.get("parameters", {}).items():
+            params[key] = technologydata.Parameter.from_dict(param_data)
+        return cls(
+            region=data["region"],
+            case=data["case"],
+            year=data["year"],
+            name=data["name"],
+            detailed_technology=data["detailed_technology"],
+            parameters=params,
+        )

--- a/technologydata/technology.py
+++ b/technologydata/technology.py
@@ -24,13 +24,13 @@ class Technology(pydantic.BaseModel):  # type: ignore
         Name of the technology.
     region : str
         Region identifier.
-    year : Optional[int]
+    year : int
         Year of the data.
     parameters : Dict[str, Parameter]
         Dictionary of parameter names to Parameter objects.
-    case : Optional[str]
+    case : str
         Case or scenario identifier.
-    detailed_technology : Optional[str]
+    detailed_technology : str
         More detailed technology name.
 
     Attributes
@@ -39,26 +39,26 @@ class Technology(pydantic.BaseModel):  # type: ignore
         Name of the technology.
     region : str
         Region identifier.
-    year : Optional[int]
+    year : int
         Year of the data.
     parameters : Dict[str, Parameter]
         Dictionary of parameter names to Parameter objects.
-    case : Optional[str]
+    case : str
         Case or scenario identifier.
-    detailed_technology : Optional[str]
+    detailed_technology : str
         More detailed technology name.
 
     """
 
     name: str = pydantic.Field(..., description="Name of the technology.")
     region: str = pydantic.Field(..., description="Region identifier.")
-    year: int | None = pydantic.Field(None, description="Year of the data.")
+    year: int = pydantic.Field(..., description="Year of the data.")
     parameters: dict[str, technologydata.Parameter] = pydantic.Field(
         default_factory=dict, description="Parameters."
     )
-    case: str | None = pydantic.Field(None, description="Case or scenario identifier.")
-    detailed_technology: str | None = pydantic.Field(
-        None, description="Detailed technology name."
+    case: str = pydantic.Field(..., description="Case or scenario identifier.")
+    detailed_technology: str = pydantic.Field(
+        ..., description="Detailed technology name."
     )
 
     def __getitem__(self, key: str) -> technologydata.Parameter:

--- a/technologydata/technology.py
+++ b/technologydata/technology.py
@@ -182,8 +182,37 @@ class Technology(pydantic.BaseModel):  # type: ignore
         return self
 
     @classmethod
-    def from_dict(cls, data):
-        # Process parameters
+    def from_dict(cls, data: dict[str, typing.Any]) -> "Technology":
+        """
+        Create an instance of the class from a dictionary.
+
+        Parameters
+        ----------
+        cls : type
+            The class to instantiate.
+        data : dict
+            A dictionary containing the data to initialize the class instance.
+            Expected keys include:
+                - "region" (str): The region associated with the instance.
+                - "case" (str): The case identifier.
+                - "year" (int): The year value.
+                - "name" (str): The name of the instance.
+                - "detailed_technology" (str): Details about the technology.
+                - "parameters" (dict): A dictionary where each key maps to a parameter data
+                  dictionary, which will be converted to a Parameter object.
+
+        Returns
+        -------
+        instance : cls
+            An instance of the class initialized with the provided data.
+
+        Notes
+        -----
+        This method processes the "parameters" field in the input data by converting each
+        parameter dictionary into a Parameter object using `Parameter.from_dict()`. It then
+        constructs and returns an instance of the class with all the provided attributes.
+
+        """
         params = {}
         for key, param_data in data.get("parameters", {}).items():
             params[key] = technologydata.Parameter.from_dict(param_data)

--- a/technologydata/technology.py
+++ b/technologydata/technology.py
@@ -11,7 +11,7 @@ import typing
 
 import pydantic
 
-import technologydata
+from technologydata.parameter import Parameter
 
 
 class Technology(pydantic.BaseModel):  # type: ignore
@@ -53,7 +53,7 @@ class Technology(pydantic.BaseModel):  # type: ignore
     name: str = pydantic.Field(..., description="Name of the technology.")
     region: str = pydantic.Field(..., description="Region identifier.")
     year: int = pydantic.Field(..., description="Year of the data.")
-    parameters: dict[str, technologydata.Parameter] = pydantic.Field(
+    parameters: dict[str, Parameter] = pydantic.Field(
         default_factory=dict, description="Parameters."
     )
     case: str = pydantic.Field(..., description="Case or scenario identifier.")
@@ -61,7 +61,7 @@ class Technology(pydantic.BaseModel):  # type: ignore
         ..., description="Detailed technology name."
     )
 
-    def __getitem__(self, key: str) -> technologydata.Parameter:
+    def __getitem__(self, key: str) -> Parameter:
         """
         Access a parameter by name.
 
@@ -78,7 +78,7 @@ class Technology(pydantic.BaseModel):  # type: ignore
         """
         return self.parameters[key]
 
-    def __setitem__(self, key: str, value: technologydata.Parameter) -> None:
+    def __setitem__(self, key: str, value: Parameter) -> None:
         """
         Set a parameter by name.
 
@@ -215,7 +215,7 @@ class Technology(pydantic.BaseModel):  # type: ignore
         """
         params = {}
         for key, param_data in data.get("parameters", {}).items():
-            params[key] = technologydata.Parameter.from_dict(param_data)
+            params[key] = Parameter.from_dict(param_data)
         return cls(
             region=data["region"],
             case=data["case"],

--- a/technologydata/technology.py
+++ b/technologydata/technology.py
@@ -18,21 +18,6 @@ class Technology(pydantic.BaseModel):  # type: ignore
     """
     Represent a technology with region, year, and a flexible set of parameters.
 
-    Parameters
-    ----------
-    name : str
-        Name of the technology.
-    region : str
-        Region identifier.
-    year : int
-        Year of the data.
-    parameters : Dict[str, Parameter]
-        Dictionary of parameter names to Parameter objects.
-    case : str
-        Case or scenario identifier.
-    detailed_technology : str
-        More detailed technology name.
-
     Attributes
     ----------
     name : str
@@ -50,16 +35,19 @@ class Technology(pydantic.BaseModel):  # type: ignore
 
     """
 
-    name: str = pydantic.Field(..., description="Name of the technology.")
-    region: str = pydantic.Field(..., description="Region identifier.")
-    year: int = pydantic.Field(..., description="Year of the data.")
-    parameters: dict[str, Parameter] = pydantic.Field(
-        default_factory=dict, description="Parameters."
-    )
-    case: str = pydantic.Field(..., description="Case or scenario identifier.")
-    detailed_technology: str = pydantic.Field(
-        ..., description="Detailed technology name."
-    )
+    name: typing.Annotated[str, pydantic.Field(description="Name of the technology.")]
+    region: typing.Annotated[str, pydantic.Field(description="Region identifier.")]
+    year: typing.Annotated[int, pydantic.Field(description="Year of the data.")]
+    parameters: typing.Annotated[
+        dict[str, Parameter],
+        pydantic.Field(default_factory=dict, description="Parameters."),
+    ]
+    case: typing.Annotated[
+        str, pydantic.Field(description="Case or scenario identifier.")
+    ]
+    detailed_technology: typing.Annotated[
+        str, pydantic.Field(description="Detailed technology name.")
+    ]
 
     def __getitem__(self, key: str) -> Parameter:
         """

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -192,6 +192,31 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
 
     @classmethod
     def from_json(cls, file_path: pathlib.Path | str) -> "TechnologyCollection":
+        """
+        Load a TechnologyCollection instance from a JSON file.
+
+        Parameters
+        ----------
+        file_path : pathlib.Path or str
+            Path to the JSON file containing the data. Can be a pathlib.Path object or a string path.
+
+        Returns
+        -------
+        TechnologyCollection
+            An instance of TechnologyCollection initialized with the data from the JSON file.
+
+        Raises
+        ------
+        TypeError
+            If `file_path` is not a pathlib.Path or str.
+
+        Notes
+        -----
+        This method reads the JSON data from the specified file, creates `Technology` objects
+        for each item in the JSON list using `Technology.from_dict()`, and returns a new
+        `TechnologyCollection` containing these objects.
+
+        """
         if isinstance(file_path, pathlib.Path | str):
             file_path = pathlib.Path(file_path)
         else:

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -192,19 +192,13 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
 
     @classmethod
     def from_json(cls, file_path: pathlib.Path | str) -> "TechnologyCollection":
-        """
-        Import the TechnologyCollection from a JSON file.
-
-        Parameters
-        ----------
-        file_path : pathlib.Path
-            The path to the JSON file to be imported.
-
-        """
         if isinstance(file_path, pathlib.Path | str):
             file_path = pathlib.Path(file_path)
         else:
             raise TypeError("file_path must be a pathlib.Path or str")
         with open(file_path, encoding="utf-8") as jsonfile:
             json_data = json.load(jsonfile)
-        return cls(**json_data)
+        techs = []
+        for item in json_data:
+            techs.append(Technology.from_dict(item))
+        return cls(technologies=techs)

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -8,6 +8,7 @@ import csv
 import json
 import pathlib
 import re
+import typing
 from collections.abc import Iterator
 
 import pandas
@@ -20,11 +21,6 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
     """
     Represent a collection of technologies.
 
-    Parameters
-    ----------
-    technologies : List[Technology]
-        List of Technology objects.
-
     Attributes
     ----------
     technologies : List[Technology]
@@ -32,9 +28,9 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
 
     """
 
-    technologies: list[Technology] = pydantic.Field(
-        ..., description="List of Technology objects."
-    )
+    technologies: typing.Annotated[
+        list[Technology], pydantic.Field(description="List of Technology objects.")
+    ]
 
     def __iter__(self) -> Iterator["Technology"]:
         """

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""SourceCollection class for representing an iterable of Source Objects."""
+"""TechnologyCollection class for representing an iterable of Technology Objects."""
 
 import csv
 import json
@@ -12,30 +12,30 @@ import re
 import pandas
 import pydantic
 
-from technologydata.source import Source
+from technologydata.technology import Technology
 
 
-class SourceCollection(pydantic.BaseModel):  # type: ignore
+class TechnologyCollection(pydantic.BaseModel):  # type: ignore
     """
-    Represent a collection of sources.
+    Represent a collection of technologies.
 
     Parameters
     ----------
-    sources : List[Source]
-        List of Source objects.
+    technologies : List[Technology]
+        List of Technology objects.
 
     Attributes
     ----------
-    sources : List[Source]
-        List of Source objects.
+    technologies : List[Technology]
+        List of Technology objects.
 
     """
 
-    sources: list[Source] = pydantic.Field(..., description="List of Source objects.")
+    technologies: list[Technology] = pydantic.Field(..., description="List of Technology objects.")
 
-    def get(self, title: str, authors: str) -> "SourceCollection":
+    def get(self, title: str, authors: str) -> "TechnologyCollection":
         """
-        Filter sources based on regex patterns for non-optional attributes.
+        Filter technologies based on regex patterns for non-optional attributes.
 
         Parameters
         ----------
@@ -46,74 +46,53 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
 
         Returns
         -------
-        SourceCollection
-            A new SourceCollection with filtered sources.
+        TechnologyCollection
+            A new TechnologyCollection with filtered technologies.
 
         """
-        filtered_sources = self.sources
+        filtered_technologies = self.technologies
 
         if title is not None:
             pattern_title = re.compile(title, re.IGNORECASE)
-            filtered_sources = [
-                s for s in filtered_sources if pattern_title.search(s.title)
+            filtered_technologies = [
+                s for s in filtered_technologies if pattern_title.search(s.title)
             ]
 
         if authors is not None:
             pattern_authors = re.compile(authors, re.IGNORECASE)
-            filtered_sources = [
-                s for s in filtered_sources if pattern_authors.search(s.authors)
+            filtered_technologies = [
+                s for s in filtered_technologies if pattern_authors.search(s.authors)
             ]
 
-        return SourceCollection(sources=filtered_sources)
+        return TechnologyCollection(technologies=filtered_technologies)
 
     def __len__(self) -> int:
         """
-        Return the number of sources in this collection.
+        Return the number of technologies in this collection.
 
         Returns
         -------
         int
-            The number of Source objects in the sources list.
+            The number of Technology objects in the technologies list.
 
         """
-        return len(self.sources)
-
-    def retrieve_all_from_wayback(
-        self, download_directory: pathlib.Path
-    ) -> list[pathlib.Path | None]:
-        """
-        Download archived files for all sources in the collection using retrieve_from_wayback.
-
-        Parameters
-        ----------
-        download_directory : pathlib.Path
-            The base directory where all files will be saved.
-
-        Returns
-        -------
-        list[pathlib.Path | None]
-            List of paths where each file was stored, or None if download failed for a source.
-
-        """
-        return [
-            source.retrieve_from_wayback(download_directory) for source in self.sources
-        ]
+        return len(self.technologies)
 
     def to_dataframe(self) -> pandas.DataFrame:
         """
-        Convert the SourceCollection to a pandas DataFrame.
+        Convert the TechnologyCollection to a pandas DataFrame.
 
         Returns
         -------
         pd.DataFrame
-            A DataFrame containing the source data.
+            A DataFrame containing the technology data.
 
         """
-        return pandas.DataFrame([source.model_dump() for source in self.sources])
+        return pandas.DataFrame([technology.model_dump() for technology in self.technologies])
 
     def to_csv(self, **kwargs: pathlib.Path | str | bool) -> None:
         """
-        Export the SourceCollection to a CSV file.
+        Export the TechnologyCollection to a CSV file.
 
         Parameters
         ----------
@@ -155,7 +134,7 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
         self, file_path: pathlib.Path, schema_path: pathlib.Path | None = None
     ) -> None:
         """
-        Export the SourceCollection to a JSON file, together with a data schema.
+        Export the TechnologyCollection to a JSON file, together with a data schema.
 
         Parameters
         ----------
@@ -180,9 +159,9 @@ class SourceCollection(pydantic.BaseModel):  # type: ignore
             jsonfile.write(json_data)
 
     @classmethod
-    def from_json(cls, file_path: pathlib.Path | str) -> "SourceCollection":
+    def from_json(cls, file_path: pathlib.Path | str) -> "TechnologyCollection":
         """
-        Import the SourceCollection from a JSON file.
+        Import the TechnologyCollection from a JSON file.
 
         Parameters
         ----------

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -8,6 +8,7 @@ import csv
 import json
 import pathlib
 import re
+from collections.abc import Iterator
 
 import pandas
 import pydantic
@@ -34,6 +35,18 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
     technologies: list[Technology] = pydantic.Field(
         ..., description="List of Technology objects."
     )
+
+    def __iter__(self) -> Iterator["Technology"]:
+        """
+        Return an iterator over the list of Technology objects.
+
+        Returns
+        -------
+        Iterator[Technology]
+            An iterator over the Technology objects contained in the collection.
+
+        """
+        return iter(self.technologies)
 
     def get(
         self, name: str, region: str, year: int, case: str, detailed_technology: str

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -48,6 +48,18 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
         """
         return iter(self.technologies)
 
+    def __len__(self) -> int:
+        """
+        Return the number of technologies in this collection.
+
+        Returns
+        -------
+        int
+            The number of Technology objects in the technologies list.
+
+        """
+        return len(self.technologies)
+
     def get(
         self, name: str, region: str, year: int, case: str, detailed_technology: str
     ) -> "TechnologyCollection":
@@ -108,18 +120,6 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
             ]
 
         return TechnologyCollection(technologies=filtered_technologies)
-
-    def __len__(self) -> int:
-        """
-        Return the number of technologies in this collection.
-
-        Returns
-        -------
-        int
-            The number of Technology objects in the technologies list.
-
-        """
-        return len(self.technologies)
 
     def to_dataframe(self) -> pandas.DataFrame:
         """

--- a/technologydata/technology_collection.py
+++ b/technologydata/technology_collection.py
@@ -31,18 +31,28 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
 
     """
 
-    technologies: list[Technology] = pydantic.Field(..., description="List of Technology objects.")
+    technologies: list[Technology] = pydantic.Field(
+        ..., description="List of Technology objects."
+    )
 
-    def get(self, title: str, authors: str) -> "TechnologyCollection":
+    def get(
+        self, name: str, region: str, year: int, case: str, detailed_technology: str
+    ) -> "TechnologyCollection":
         """
         Filter technologies based on regex patterns for non-optional attributes.
 
         Parameters
         ----------
-        title : str
-            Regex pattern to filter titles.
-        authors : str
-            Regex pattern to filter authors.
+        name : str
+            Regex pattern to filter technology names.
+        region : str
+            Regex pattern to filter region identifiers.
+        year : int
+            Regex pattern to filter the year of the data.
+        case : str
+            Regex pattern to filter case or scenario identifiers.
+        detailed_technology : str
+            Regex pattern to filter detailed technology names.
 
         Returns
         -------
@@ -52,16 +62,36 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
         """
         filtered_technologies = self.technologies
 
-        if title is not None:
-            pattern_title = re.compile(title, re.IGNORECASE)
+        if name is not None:
+            pattern_name = re.compile(name, re.IGNORECASE)
             filtered_technologies = [
-                s for s in filtered_technologies if pattern_title.search(s.title)
+                t for t in filtered_technologies if pattern_name.search(t.name)
             ]
 
-        if authors is not None:
-            pattern_authors = re.compile(authors, re.IGNORECASE)
+        if region is not None:
+            pattern_region = re.compile(region, re.IGNORECASE)
             filtered_technologies = [
-                s for s in filtered_technologies if pattern_authors.search(s.authors)
+                t for t in filtered_technologies if pattern_region.search(t.region)
+            ]
+
+        if year is not None:
+            pattern_year = re.compile(str(year), re.IGNORECASE)
+            filtered_technologies = [
+                t for t in filtered_technologies if pattern_year.search(str(t.year))
+            ]
+
+        if case is not None:
+            pattern_case = re.compile(case, re.IGNORECASE)
+            filtered_technologies = [
+                t for t in filtered_technologies if pattern_case.search(t.case)
+            ]
+
+        if detailed_technology is not None:
+            pattern_detailed_technology = re.compile(detailed_technology, re.IGNORECASE)
+            filtered_technologies = [
+                t
+                for t in filtered_technologies
+                if pattern_detailed_technology.search(t.detailed_technology)
             ]
 
         return TechnologyCollection(technologies=filtered_technologies)
@@ -88,7 +118,9 @@ class TechnologyCollection(pydantic.BaseModel):  # type: ignore
             A DataFrame containing the technology data.
 
         """
-        return pandas.DataFrame([technology.model_dump() for technology in self.technologies])
+        return pandas.DataFrame(
+            [technology.model_dump() for technology in self.technologies]
+        )
 
     def to_csv(self, **kwargs: pathlib.Path | str | bool) -> None:
         """

--- a/technologydata/unit_value.py
+++ b/technologydata/unit_value.py
@@ -17,6 +17,8 @@ Examples
 
 """
 
+import typing
+
 import pint
 import pydantic
 
@@ -27,13 +29,6 @@ class UnitValue(pydantic.BaseModel):  # type: ignore
     """
     Represent a numerical value with an associated unit of measurement.
 
-    Parameters
-    ----------
-    value : float
-        The numerical value.
-    unit : str
-        The unit of measurement (e.g., 'EUR_2020', 'kWh_electricity', 'kWh_hydrogen_LHV').
-
     Attributes
     ----------
     value : float
@@ -43,8 +38,8 @@ class UnitValue(pydantic.BaseModel):  # type: ignore
 
     """
 
-    value: float = pydantic.Field(..., description="The numerical value.")
-    unit: str = pydantic.Field(..., description="The unit of measurement.")
+    value: typing.Annotated[float, pydantic.Field(description="The numerical value.")]
+    unit: typing.Annotated[str, pydantic.Field(description="The unit of measurement.")]
 
     def to(self, new_unit: str) -> "UnitValue":
         """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,25 +42,13 @@ def create_source_from_params(params: dict[str, str]) -> technologydata.Source:
 
     Returns
     -------
-    td.Source
+    technologydata.Source
         A Source object initialized with the provided parameters.
 
     Raises
     ------
     ValueError
         If any of the required fields ("source_title", "source_authors") are missing from the params.
-
-    Examples
-    --------
-    >>> params_dict = {
-    ...     "source_title": "Example Title",
-    ...     "source_authors": "John Doe",
-    ...     "source_url": "http://example.com",
-    ...     "source_url_archive": "http://web.archive.org/web/20231001120000/http://example.com",
-    ...     "source_url_date": "2023-10-01",
-    ...     "source_url_date_archive": "2023-10-01T12:00:00Z"
-    ... }
-    >>> source = create_source_from_params(params_dict)
 
     """
     return technologydata.Source(

--- a/test/test_data/solar_photovoltaics_example_03/technologies.json
+++ b/test/test_data/solar_photovoltaics_example_03/technologies.json
@@ -3,170 +3,174 @@
     "region": "DEU",
     "case": "example-scenario",
     "year": 2022,
-    "technology": "Solar photovoltaics",
+    "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
-    "capacity": {
-      "quantity": {
-        "value": 1,
-        "unit": "MW"
-      },
-      "provenance": "Model calculation",
-      "note": "Average capacity factor of 22% assumed",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+    "parameters": {
+      "capacity": {
+        "quantity": {
+          "value": 1,
+          "unit": "MW"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
-    },
-    "investment": {
-      "quantity": {
-        "value": 500,
-        "unit": "EUR_2022/KW_el"
+        "provenance": "Model calculation",
+        "note": "Average capacity factor of 22% assumed",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
       },
-      "provenance": "Industry report",
-      "note": "Average overnight cost",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+      "investment": {
+        "quantity": {
+          "value": 500,
+          "unit": "EUR_2022/KW_el"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
-    },
-    "specific_investment": {
-      "quantity": {
-        "value": 0.95,
-        "unit": "USD/W"
+        "provenance": "Industry report",
+        "note": "Average overnight cost",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
       },
-      "provenance": "Derived",
-      "note": "Calculated from investment/capacity",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+      "specific_investment": {
+        "quantity": {
+          "value": 0.95,
+          "unit": "USD/W"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
-    },
-    "lifetime": {
-      "quantity": {
-        "value": 30,
-        "unit": "years"
+        "provenance": "Derived",
+        "note": "Calculated from investment/capacity",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
       },
-      "provenance": "Manufacturer specification",
-      "note": "With performance degradation guarantee",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+      "lifetime": {
+        "quantity": {
+          "value": 30,
+          "unit": "years"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
-    },
-    "wacc": {
-      "quantity": {
-        "value": 0.05,
-        "unit": "fraction"
+        "provenance": "Manufacturer specification",
+        "note": "With performance degradation guarantee",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
       },
-      "provenance": "Financial analysis",
-      "note": "Nominal weighted average cost of capital",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+      "wacc": {
+        "quantity": {
+          "value": 0.05,
+          "unit": "fraction"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
+        "provenance": "Financial analysis",
+        "note": "Nominal weighted average cost of capital",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
+      }
     }
   },
   {
     "region": "DEU",
     "case": "example-project",
     "year": 2022,
-    "technology": "Solar photovoltaics",
+    "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
-    "capacity": {
-      "quantity": {
-        "value": 1.0,
-        "unit": "MW"
-      },
-      "provenance": "Model calculation",
-      "note": "Average capacity factor of 25% assumed",
-      "sources": [
-        {
-          "title": "atb_nrel",
-          "authors": "NREL/ATB",
-          "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-          "url_date": "2025-05-22 15:08:02",
-          "url_date_archive": "2025-05-22 15:08:02"
+    "parameters": {
+      "capacity": {
+        "quantity": {
+          "value": 1.0,
+          "unit": "MW"
         },
-        {
-          "title": "tech_data_generation",
-          "authors": "Danish Energy Agency",
-          "url": "https://ens.dk/media/3273/download",
-          "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-          "url_date": "2025-05-06 16:02:04",
-          "url_date_archive": "2025-05-06 16:02:04"
-        }
-      ]
+        "provenance": "Model calculation",
+        "note": "Average capacity factor of 25% assumed",
+        "sources": [
+          {
+            "title": "atb_nrel",
+            "authors": "NREL/ATB",
+            "url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+            "url_date": "2025-05-22 15:08:02",
+            "url_date_archive": "2025-05-22 15:08:02"
+          },
+          {
+            "title": "tech_data_generation",
+            "authors": "Danish Energy Agency",
+            "url": "https://ens.dk/media/3273/download",
+            "url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+            "url_date": "2025-05-06 16:02:04",
+            "url_date_archive": "2025-05-06 16:02:04"
+          }
+        ]
+      }
     },
     "investment": {
       "quantity": {

--- a/test/test_data/solar_photovoltaics_example_04/technologies.json
+++ b/test/test_data/solar_photovoltaics_example_04/technologies.json
@@ -5,80 +5,82 @@
     "year": 2022,
     "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
-    "capacity": {
-      "quantity": {
-        "value": 1,
-        "unit": "MW"
+    "parameters": {
+      "capacity": {
+        "quantity": {
+          "value": 1,
+          "unit": "MW"
+        },
+        "provenance": "Model calculation",
+        "note": "Average capacity factor of 22% assumed",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Model calculation",
-      "note": "Average capacity factor of 22% assumed",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "investment": {
-      "quantity": {
-        "value": 500,
-        "unit": "EUR_2022/KW_el"
+      "investment": {
+        "quantity": {
+          "value": 500,
+          "unit": "EUR_2022/KW_el"
+        },
+        "provenance": "Industry report",
+        "note": "Average overnight cost",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Industry report",
-      "note": "Average overnight cost",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "specific_investment": {
-      "quantity": {
-        "value": 0.95,
-        "unit": "USD/W"
+      "specific_investment": {
+        "quantity": {
+          "value": 0.95,
+          "unit": "USD/W"
+        },
+        "provenance": "Derived",
+        "note": "Calculated from investment/capacity",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Derived",
-      "note": "Calculated from investment/capacity",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "lifetime": {
-      "quantity": {
-        "value": 30,
-        "unit": "years"
+      "lifetime": {
+        "quantity": {
+          "value": 30,
+          "unit": "years"
+        },
+        "provenance": "Manufacturer specification",
+        "note": "With performance degradation guarantee",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Manufacturer specification",
-      "note": "With performance degradation guarantee",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "wacc": {
-      "quantity": {
-        "value": 0.05,
-        "unit": "fraction"
-      },
-      "provenance": "Financial analysis",
-      "note": "Nominal weighted average cost of capital",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
+      "wacc": {
+        "quantity": {
+          "value": 0.05,
+          "unit": "fraction"
+        },
+        "provenance": "Financial analysis",
+        "note": "Nominal weighted average cost of capital",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
+      }
     }
   },
   {
@@ -87,80 +89,82 @@
     "year": 2022,
     "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
-    "capacity": {
-      "quantity": {
-        "value": 1.0,
-        "unit": "MW"
+    "parameters": {
+      "capacity": {
+        "quantity": {
+          "value": 1.0,
+          "unit": "MW"
+        },
+        "provenance": "Model calculation",
+        "note": "Average capacity factor of 25% assumed",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Model calculation",
-      "note": "Average capacity factor of 25% assumed",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "investment": {
-      "quantity": {
-        "value": 350,
-        "unit": "EUR_2022/KW_el"
+      "investment": {
+        "quantity": {
+          "value": 350,
+          "unit": "EUR_2022/KW_el"
+        },
+        "provenance": "Industry report",
+        "note": "Average overnight cost for another tech",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Industry report",
-      "note": "Average overnight cost for another tech",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "specific_investment": {
-      "quantity": {
-        "value": 0.95,
-        "unit": "USD/W"
+      "specific_investment": {
+        "quantity": {
+          "value": 0.95,
+          "unit": "USD/W"
+        },
+        "provenance": "Derived",
+        "note": "Calculated from investment/capacity",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Derived",
-      "note": "Calculated from investment/capacity",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "lifetime": {
-      "quantity": {
-        "value": 30,
-        "unit": "years"
+      "lifetime": {
+        "quantity": {
+          "value": 30,
+          "unit": "years"
+        },
+        "provenance": "Manufacturer specification",
+        "note": "With performance degradation guarantee",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
       },
-      "provenance": "Manufacturer specification",
-      "note": "With performance degradation guarantee",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
-    },
-    "wacc": {
-      "quantity": {
-        "value": 0.05,
-        "unit": "fraction"
-      },
-      "provenance": "Financial analysis",
-      "note": "Nominal weighted average cost of capital",
-      "sources": [
-        {
-          "title": "example04",
-          "authors": "Open Energy Transition gGmbH",
-          "url": "https://openenergytransition.org/outputs.html"
-        }
-      ]
+      "wacc": {
+        "quantity": {
+          "value": 0.05,
+          "unit": "fraction"
+        },
+        "provenance": "Financial analysis",
+        "note": "Nominal weighted average cost of capital",
+        "sources": [
+          {
+            "title": "example04",
+            "authors": "Open Energy Transition gGmbH",
+            "url": "https://openenergytransition.org/outputs.html"
+          }
+        ]
+      }
     }
   }
 ]

--- a/test/test_data/solar_photovoltaics_example_04/technologies.json
+++ b/test/test_data/solar_photovoltaics_example_04/technologies.json
@@ -3,7 +3,7 @@
     "region": "DEU",
     "case": "example-scenario",
     "year": 2022,
-    "technology": "Solar photovoltaics",
+    "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
     "capacity": {
       "quantity": {
@@ -85,7 +85,7 @@
     "region": "DEU",
     "case": "example-project",
     "year": 2022,
-    "technology": "Solar photovoltaics",
+    "name": "Solar photovoltaics",
     "detailed_technology": "Si-HC",
     "capacity": {
       "quantity": {

--- a/test/test_datapackage.py
+++ b/test/test_datapackage.py
@@ -22,7 +22,6 @@ def test_get_source_collection() -> None:
     )
     technologies_collection = technologydata.TechnologyCollection.from_json(input_file)
     data_package = technologydata.DataPackage(
-        path=pathlib.Path(path_cwd, "test_package"),
         technologies=technologies_collection,
     )
     data_package.get_source_collection()

--- a/test/test_datapackage.py
+++ b/test/test_datapackage.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: The technology-data authors
+#
+# SPDX-License-Identifier: MIT
+
+"""Test the initialization and methods of the Datapackage class."""
+
+import datetime
+import pathlib
+
+import pytest
+
+import technologydata
+
+path_cwd = pathlib.Path.cwd()
+
+
+def test_get_source_collection() -> None:
+    """Test how the sources attributes is extracted from a TechnologyCollection instance."""
+    input_file = pathlib.Path(
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
+    )
+    technologies_collection = technologydata.TechnologyCollection.from_json(input_file)
+    data_package = technologydata.DataPackage(
+        name="test_package",
+        path=pathlib.Path(path_cwd, "test_package"),
+        technologies=technologies_collection,
+    )
+    assert isinstance(data_package.get_source_collection(), technologydata.SourceCollection)

--- a/test/test_datapackage.py
+++ b/test/test_datapackage.py
@@ -22,7 +22,6 @@ def test_get_source_collection() -> None:
     )
     technologies_collection = technologydata.TechnologyCollection.from_json(input_file)
     data_package = technologydata.DataPackage(
-        name="test_package",
         path=pathlib.Path(path_cwd, "test_package"),
         technologies=technologies_collection,
     )

--- a/test/test_datapackage.py
+++ b/test/test_datapackage.py
@@ -4,10 +4,7 @@
 
 """Test the initialization and methods of the Datapackage class."""
 
-import datetime
 import pathlib
-
-import pytest
 
 import technologydata
 
@@ -29,4 +26,6 @@ def test_get_source_collection() -> None:
         path=pathlib.Path(path_cwd, "test_package"),
         technologies=technologies_collection,
     )
-    assert isinstance(data_package.get_source_collection(), technologydata.SourceCollection)
+    data_package.get_source_collection()
+    assert isinstance(data_package.sources, technologydata.SourceCollection)
+    assert len(data_package.sources) == 2

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -15,6 +15,47 @@ path_cwd = pathlib.Path.cwd()
 
 
 @pytest.mark.parametrize(
+    "example_source, expected_equal",
+    [
+        (
+            {
+                "source_title": "atb_nrel",
+                "source_authors": "NREL/ATB",
+                "source_url": "https:download",
+                "source_url_archive": "http:/3273/download",
+                "source_url_date": "2025-05-22 15:08:02",
+                "source_url_date_archive": "2025-05-22 15:08:02",
+            },
+            False,  # Expect not equal
+        ),
+        (
+            {
+                "source_title": "tech_data_generation",
+                "source_authors": "Danish Energy Agency",
+                "source_url": "https:download",
+                "source_url_archive": "http:/3273/download",
+                "source_url_date": "2025-05-06 16:02:04",
+                "source_url_date_archive": "2025-05-06 16:02:04",
+            },
+            True,  # Expect equal
+        ),
+    ],
+    indirect=["example_source"],
+)  # type: ignore
+def test_eq(example_source: technologydata.Source, expected_equal: bool) -> None:
+    """Check if the override method eq works as expected."""
+    reference_source = technologydata.Source(
+        title="tech_data_generation",
+        authors="Danish Energy Agency",
+        url="https:download",
+        url_archive="http:/3273/download",
+        url_date="2025-05-06 16:02:04",
+        url_date_archive="2025-05-06 16:02:04",
+    )
+    assert (example_source == reference_source) == expected_equal
+
+
+@pytest.mark.parametrize(
     "example_source, expected_string",
     [
         (
@@ -57,7 +98,7 @@ def test_str(example_source: technologydata.Source, expected_string: str) -> Non
             "source_url_date_archive": "2025-05-06 16:02:04",
         },
     ],
-    indirect=True,
+    indirect=["example_source"],
 )  # type: ignore
 def test_retrieve_from_wayback(example_source: technologydata.Source) -> None:
     """Check if the example source is downloaded from the Internet Archive Wayback Machine."""

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -15,6 +15,26 @@ path_cwd = pathlib.Path.cwd()
 
 
 @pytest.mark.parametrize(
+    "example_source, expected_string",
+    [
+        (
+            {
+                "source_title": "OET project page",
+                "source_authors": "Open Energy Transition gGmbH",
+                "source_url": "https://openenergytransition.org/outputs.html",
+            },
+            "Title: 'OET project page', Authors: 'Open Energy Transition gGmbH', URL: 'https://openenergytransition.org/outputs.html'",
+        )
+    ],
+    indirect=["example_source"],
+)  # type: ignore
+def test_str(example_source: technologydata.Source, expected_string: str) -> None:
+    """Check if the override method str works as expected."""
+    # Ensure the snapshot is created
+    assert str(example_source) == expected_string
+
+
+@pytest.mark.parametrize(
     "example_source",
     [
         {

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -43,7 +43,7 @@ path_cwd = pathlib.Path.cwd()
     indirect=["example_source"],
 )  # type: ignore
 def test_eq(example_source: technologydata.Source, expected_equal: bool) -> None:
-    """Check if the override method eq works as expected."""
+    """Check if the override method __eq__ works as expected."""
     reference_source = technologydata.Source(
         title="tech_data_generation",
         authors="Danish Energy Agency",
@@ -53,6 +53,31 @@ def test_eq(example_source: technologydata.Source, expected_equal: bool) -> None
         url_date_archive="2025-05-06 16:02:04",
     )
     assert (example_source == reference_source) == expected_equal
+
+
+@pytest.mark.parametrize(
+    "example_source",
+    [
+        {
+            "source_title": "atb_nrel",
+            "source_authors": "NREL/ATB",
+            "source_url_archive": "http:/3273/download",
+            "source_url_date_archive": "2025-05-22 15:08:02",
+        },
+        {
+            "source_title": "tech_data_generation",
+            "source_authors": "Danish Energy Agency",
+            "source_url": "https:download",
+            "source_url_archive": "http:/3273/download",
+            "source_url_date": "2025-05-06 16:02:04",
+            "source_url_date_archive": "2025-05-06 16:02:04",
+        },
+    ],
+    indirect=["example_source"],
+)  # type: ignore
+def test_hash(example_source: technologydata.Source) -> None:
+    """Check if the override method __hash__ works as expected."""
+    assert isinstance(hash(example_source), int)
 
 
 @pytest.mark.parametrize(
@@ -73,7 +98,7 @@ def test_eq(example_source: technologydata.Source, expected_equal: bool) -> None
     indirect=["example_source"],
 )  # type: ignore
 def test_str(example_source: technologydata.Source, expected_string: str) -> None:
-    """Check if the override method str works as expected."""
+    """Check if the override method __str__ works as expected."""
     # Ensure the snapshot is created
     assert str(example_source) == expected_string
 

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -39,6 +39,13 @@ path_cwd = pathlib.Path.cwd()
             },
             True,  # Expect equal
         ),
+        (
+            {
+                "source_title": "tech_data_generation",
+                "source_authors": "Danish Energy Agency",
+            },
+            False,  # Expect not equal
+        ),
     ],
     indirect=["example_source"],
 )  # type: ignore

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -21,9 +21,12 @@ path_cwd = pathlib.Path.cwd()
             {
                 "source_title": "OET project page",
                 "source_authors": "Open Energy Transition gGmbH",
-                "source_url": "https://openenergytransition.org/outputs.html",
+                "source_url": "https://outputs.html",
+                "source_url_archive": "https:archived.html",
+                "source_url_date": "2025-05-06 16:02:04",
+                "source_url_date_archive": "2025-05-06 16:02:04",
             },
-            "Title: 'OET project page', Authors: 'Open Energy Transition gGmbH', URL: 'https://openenergytransition.org/outputs.html'",
+            "'Open Energy Transition gGmbH': 'OET project page', from url 'https://outputs.html', last accessed on '2025-05-06 16:02:04', archived at 'https:archived.html', on '2025-05-06 16:02:04'.",
         )
     ],
     indirect=["example_source"],

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -58,7 +58,7 @@ def test_str(
             },
         ]
     ],
-    indirect=True,
+    indirect=["example_source_collection"],
 )  # type: ignore
 def test_example_source_collection(
     example_source_collection: technologydata.SourceCollection,
@@ -99,7 +99,7 @@ def test_example_source_collection(
             },
         ],
     ],
-    indirect=True,
+    indirect=["example_source_collection"],
 )  # type: ignore
 def test_retrieve_all_from_wayback(
     example_source_collection: technologydata.SourceCollection,
@@ -148,7 +148,7 @@ def test_retrieve_all_from_wayback(
             },
         ],
     ],
-    indirect=True,
+    indirect=["example_source_collection"],
 )  # type: ignore
 def test_to_csv(example_source_collection: technologydata.SourceCollection) -> None:
     """Check if the example source collection is exported to CSV."""
@@ -180,7 +180,7 @@ def test_to_csv(example_source_collection: technologydata.SourceCollection) -> N
             },
         ],
     ],
-    indirect=True,
+    indirect=["example_source_collection"],
 )  # type: ignore
 def test_to_json(example_source_collection: technologydata.SourceCollection) -> None:
     """Check if the example source collection is exported to JSON."""
@@ -215,7 +215,7 @@ def test_to_json(example_source_collection: technologydata.SourceCollection) -> 
             },
         ],
     ],
-    indirect=True,
+    indirect=["example_source_collection"],
 )  # type: ignore
 def test_to_dataframe(
     example_source_collection: technologydata.SourceCollection,

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -225,7 +225,7 @@ def test_to_dataframe(
 
 
 def test_from_json() -> None:
-    """Check if the example source collection is exported to JSON."""
+    """Check if the example source collection is imported from JSON."""
     input_file = pathlib.Path(
         path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
     )

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -31,8 +31,8 @@ path_cwd = pathlib.Path.cwd()
                 },
             ],
             "SourceCollection with 2 sources: "
-            "Title: 'atb_nrel', Authors: 'NREL/ATB', URL Date: '2025-05-22 15:08:02', "
-            "Title: 'tech_data_generation', Authors: 'Danish Energy Agency', URL Date Archive: '2025-05-06 16:02:04'",
+            "'NREL/ATB': 'atb_nrel', last accessed on '2025-05-22 15:08:02', "
+            "'Danish Energy Agency': 'tech_data_generation', on '2025-05-06 16:02:04'.",
         ),
     ],
     indirect=["example_source_collection"],

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -155,7 +155,7 @@ def test_to_csv(example_source_collection: technologydata.SourceCollection) -> N
 def test_to_json(example_source_collection: technologydata.SourceCollection) -> None:
     """Check if the example source collection is exported to JSON."""
     output_file = pathlib.Path(path_cwd, "sources.json")
-    schema_file = pathlib.Path(path_cwd, "source_collection_schema.json")
+    schema_file = pathlib.Path(path_cwd, "sources.schema.json")
     example_source_collection.to_json(pathlib.Path(output_file))
     assert output_file.is_file()
     assert schema_file.is_file()

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -15,6 +15,36 @@ path_cwd = pathlib.Path.cwd()
 
 
 @pytest.mark.parametrize(
+    "example_source_collection, expected_string",
+    [
+        (
+            [
+                {
+                    "source_title": "atb_nrel",
+                    "source_authors": "NREL/ATB",
+                    "source_url_date": "2025-05-22 15:08:02",
+                },
+                {
+                    "source_title": "tech_data_generation",
+                    "source_authors": "Danish Energy Agency",
+                    "source_url_date_archive": "2025-05-06 16:02:04",
+                },
+            ],
+            "SourceCollection with 2 sources: "
+            "Title: 'atb_nrel', Authors: 'NREL/ATB', URL Date: '2025-05-22 15:08:02', "
+            "Title: 'tech_data_generation', Authors: 'Danish Energy Agency', URL Date Archive: '2025-05-06 16:02:04'",
+        ),
+    ],
+    indirect=["example_source_collection"],
+)  # type: ignore
+def test_str(
+    example_source_collection: technologydata.SourceCollection, expected_string: str
+) -> None:
+    """Check if the example source collection is cast to string as expected."""
+    assert str(example_source_collection) == expected_string
+
+
+@pytest.mark.parametrize(
     "example_source_collection",
     [
         [

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -229,7 +229,7 @@ def test_from_json() -> None:
     input_file = pathlib.Path(
         path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
     )
-    source_collection = technologydata.SourceCollection.from_json(input_file)
+    source_collection = technologydata.SourceCollection.from_json(file_path=input_file)
     assert isinstance(source_collection, technologydata.SourceCollection)
     assert len(source_collection) == 2
 
@@ -244,6 +244,6 @@ def test_get(title_pattern: str, authors_pattern: str) -> None:
         path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
     )
 
-    source_collection = technologydata.SourceCollection.from_json(input_file)
+    source_collection = technologydata.SourceCollection.from_json(file_path=input_file)
     result = source_collection.get(title=title_pattern, authors=authors_pattern)
     assert len(result.sources) == 1

--- a/test/test_technology_collection.py
+++ b/test/test_technology_collection.py
@@ -17,13 +17,17 @@ path_cwd = pathlib.Path.cwd()
 def test_to_csv() -> None:
     """Check if the example technology collection is exported to CSV."""
     input_file = pathlib.Path(
-        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "technologies.json"
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
     )
     technology_collection = technologydata.TechnologyCollection.from_json(input_file)
-    output_file = pathlib.Path(path_cwd, "export.csv")
+    output_file = pathlib.Path(path_cwd, "technologies.csv")
     technology_collection.to_csv(path_or_buf=output_file)
     assert output_file.is_file()
-    #output_file.unlink(missing_ok=True)
+    output_file.unlink(missing_ok=True)
 
 
 @pytest.mark.parametrize(

--- a/test/test_technology_collection.py
+++ b/test/test_technology_collection.py
@@ -94,7 +94,6 @@ def test_get(
         "solar_photovoltaics_example_03",
         "technologies.json",
     )
-
     technologies_collection = technologydata.TechnologyCollection.from_json(input_file)
     result = technologies_collection.get(
         name=name,
@@ -103,4 +102,5 @@ def test_get(
         case=case,
         detailed_technology=detailed_technology,
     )
+    assert isinstance(result, technologydata.TechnologyCollection)
     assert len(result.technologies) == 1

--- a/test/test_technology_collection.py
+++ b/test/test_technology_collection.py
@@ -78,7 +78,10 @@ def test_from_json() -> None:
 
 @pytest.mark.parametrize(
     "name, region, year, case, detailed_technology",
-    [["Solar photovoltaics", "DEU", 2022, "example-scenario", "Si-HC"], ["Solar photovoltaics", "DEU", 2022, "example-project", "Si-HC"]],
+    [
+        ["Solar photovoltaics", "DEU", 2022, "example-scenario", "Si-HC"],
+        ["Solar photovoltaics", "DEU", 2022, "example-project", "Si-HC"],
+    ],
 )  # type: ignore
 def test_get(
     name: str, region: str, year: int, case: str, detailed_technology: str

--- a/test/test_technology_collection.py
+++ b/test/test_technology_collection.py
@@ -30,92 +30,74 @@ def test_to_csv() -> None:
     output_file.unlink(missing_ok=True)
 
 
-@pytest.mark.parametrize(
-    "example_source_collection",
-    [
-        [
-            {
-                "source_title": "atb_nrel",
-                "source_authors": "NREL/ATB",
-                "source_url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-                "source_url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-                "source_url_date": "2025-05-22 15:08:02",
-                "source_url_date_archive": "2025-05-22 15:08:02",
-            },
-            {
-                "source_title": "tech_data_generation",
-                "source_authors": "Danish Energy Agency",
-                "source_url": "https://ens.dk/media/3273/download",
-                "source_url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-                "source_url_date": "2025-05-06 16:02:04",
-                "source_url_date_archive": "2025-05-06 16:02:04",
-            },
-        ],
-    ],
-    indirect=True,
-)  # type: ignore
-def test_to_json(example_source_collection: technologydata.SourceCollection) -> None:
-    """Check if the example source collection is exported to JSON."""
-    output_file = pathlib.Path(path_cwd, "sources.json")
-    schema_file = pathlib.Path(path_cwd, "source_collection_schema.json")
-    example_source_collection.to_json(pathlib.Path(output_file))
+def test_to_dataframe() -> None:
+    """Check if the example technology collection is exported to pandas dataframe."""
+    input_file = pathlib.Path(
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
+    )
+    technology_collection = technologydata.TechnologyCollection.from_json(input_file)
+    assert isinstance(technology_collection.to_dataframe(), pandas.DataFrame)
+
+
+def test_to_json() -> None:
+    """Check if the example technology collection is exported to JSON."""
+    input_file = pathlib.Path(
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
+    )
+    technology_collection = technologydata.TechnologyCollection.from_json(input_file)
+    output_file = pathlib.Path(path_cwd, "technologies.json")
+    schema_file = pathlib.Path(path_cwd, "technologies.schema.json")
+    technology_collection.to_json(pathlib.Path(output_file))
     assert output_file.is_file()
     assert schema_file.is_file()
     output_file.unlink(missing_ok=True)
     schema_file.unlink(missing_ok=True)
 
 
-@pytest.mark.parametrize(
-    "example_source_collection",
-    [
-        [
-            {
-                "source_title": "atb_nrel",
-                "source_authors": "NREL/ATB",
-                "source_url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-                "source_url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
-                "source_url_date": "2025-05-22 15:08:02",
-                "source_url_date_archive": "2025-05-22 15:08:02",
-            },
-            {
-                "source_title": "tech_data_generation",
-                "source_authors": "Danish Energy Agency",
-                "source_url": "https://ens.dk/media/3273/download",
-                "source_url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
-                "source_url_date": "2025-05-06 16:02:04",
-                "source_url_date_archive": "2025-05-06 16:02:04",
-            },
-        ],
-    ],
-    indirect=True,
-)  # type: ignore
-def test_to_dataframe(
-    example_source_collection: technologydata.SourceCollection,
-) -> None:
-    """Check if the example source collection is exported to pandas dataframe."""
-    assert isinstance(example_source_collection.to_dataframe(), pandas.DataFrame)
-
-
 def test_from_json() -> None:
-    """Check if the example source collection is exported to JSON."""
+    """Check if the example technology collection is imported from JSON."""
     input_file = pathlib.Path(
-        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
     )
-    source_collection = technologydata.SourceCollection.from_json(input_file)
-    assert isinstance(source_collection, technologydata.SourceCollection)
-    assert len(source_collection) == 2
+    technology_collection = technologydata.TechnologyCollection.from_json(input_file)
+    assert isinstance(technology_collection, technologydata.TechnologyCollection)
+    assert len(technology_collection) == 2
 
 
 @pytest.mark.parametrize(
-    "title_pattern, authors_pattern",
-    [["ATB", "nrel"], ["TECH_DATA", "danish"]],
+    "name, region, year, case, detailed_technology",
+    [["Solar photovoltaics", "DEU", 2022, "example-scenario", "Si-HC"], ["Solar photovoltaics", "DEU", 2022, "example-project", "Si-HC"]],
 )  # type: ignore
-def test_get(title_pattern: str, authors_pattern: str) -> None:
-    """Check if the example source collection is filtered as requested."""
+def test_get(
+    name: str, region: str, year: int, case: str, detailed_technology: str
+) -> None:
+    """Check if the example technology collection is filtered as requested."""
     input_file = pathlib.Path(
-        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
+        path_cwd,
+        "test",
+        "test_data",
+        "solar_photovoltaics_example_03",
+        "technologies.json",
     )
 
-    source_collection = technologydata.SourceCollection.from_json(input_file)
-    result = source_collection.get(title=title_pattern, authors=authors_pattern)
-    assert len(result.sources) == 1
+    technologies_collection = technologydata.TechnologyCollection.from_json(input_file)
+    result = technologies_collection.get(
+        name=name,
+        region=region,
+        year=year,
+        case=case,
+        detailed_technology=detailed_technology,
+    )
+    assert len(result.technologies) == 1

--- a/test/test_technology_collection.py
+++ b/test/test_technology_collection.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: The technology-data authors
+#
+# SPDX-License-Identifier: MIT
+
+"""Test the initialization and methods of the TechnologyCollection class."""
+
+import pathlib
+
+import pandas
+import pytest
+
+import technologydata
+
+path_cwd = pathlib.Path.cwd()
+
+
+def test_to_csv() -> None:
+    """Check if the example technology collection is exported to CSV."""
+    input_file = pathlib.Path(
+        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "technologies.json"
+    )
+    technology_collection = technologydata.TechnologyCollection.from_json(input_file)
+    output_file = pathlib.Path(path_cwd, "export.csv")
+    technology_collection.to_csv(path_or_buf=output_file)
+    assert output_file.is_file()
+    #output_file.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    "example_source_collection",
+    [
+        [
+            {
+                "source_title": "atb_nrel",
+                "source_authors": "NREL/ATB",
+                "source_url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+                "source_url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+                "source_url_date": "2025-05-22 15:08:02",
+                "source_url_date_archive": "2025-05-22 15:08:02",
+            },
+            {
+                "source_title": "tech_data_generation",
+                "source_authors": "Danish Energy Agency",
+                "source_url": "https://ens.dk/media/3273/download",
+                "source_url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+                "source_url_date": "2025-05-06 16:02:04",
+                "source_url_date_archive": "2025-05-06 16:02:04",
+            },
+        ],
+    ],
+    indirect=True,
+)  # type: ignore
+def test_to_json(example_source_collection: technologydata.SourceCollection) -> None:
+    """Check if the example source collection is exported to JSON."""
+    output_file = pathlib.Path(path_cwd, "sources.json")
+    schema_file = pathlib.Path(path_cwd, "source_collection_schema.json")
+    example_source_collection.to_json(pathlib.Path(output_file))
+    assert output_file.is_file()
+    assert schema_file.is_file()
+    output_file.unlink(missing_ok=True)
+    schema_file.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    "example_source_collection",
+    [
+        [
+            {
+                "source_title": "atb_nrel",
+                "source_authors": "NREL/ATB",
+                "source_url": "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+                "source_url_archive": "https://web.archive.org/web/20250522150802/https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/2024/v3.0.0/ATBe.parquet",
+                "source_url_date": "2025-05-22 15:08:02",
+                "source_url_date_archive": "2025-05-22 15:08:02",
+            },
+            {
+                "source_title": "tech_data_generation",
+                "source_authors": "Danish Energy Agency",
+                "source_url": "https://ens.dk/media/3273/download",
+                "source_url_archive": "http://web.archive.org/web/20250506160204/https://ens.dk/media/3273/download",
+                "source_url_date": "2025-05-06 16:02:04",
+                "source_url_date_archive": "2025-05-06 16:02:04",
+            },
+        ],
+    ],
+    indirect=True,
+)  # type: ignore
+def test_to_dataframe(
+    example_source_collection: technologydata.SourceCollection,
+) -> None:
+    """Check if the example source collection is exported to pandas dataframe."""
+    assert isinstance(example_source_collection.to_dataframe(), pandas.DataFrame)
+
+
+def test_from_json() -> None:
+    """Check if the example source collection is exported to JSON."""
+    input_file = pathlib.Path(
+        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
+    )
+    source_collection = technologydata.SourceCollection.from_json(input_file)
+    assert isinstance(source_collection, technologydata.SourceCollection)
+    assert len(source_collection) == 2
+
+
+@pytest.mark.parametrize(
+    "title_pattern, authors_pattern",
+    [["ATB", "nrel"], ["TECH_DATA", "danish"]],
+)  # type: ignore
+def test_get(title_pattern: str, authors_pattern: str) -> None:
+    """Check if the example source collection is filtered as requested."""
+    input_file = pathlib.Path(
+        path_cwd, "test", "test_data", "solar_photovoltaics_example_03", "sources.json"
+    )
+
+    source_collection = technologydata.SourceCollection.from_json(input_file)
+    result = source_collection.get(title=title_pattern, authors=authors_pattern)
+    assert len(result.sources) == 1


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This pull request proposed the following changes.

**Changes to existing files**

- **docs/class-diagram.puml**: small typos and minor changes, to keep the file up-to-date with the latest development
- **technologydata/__init__.py**: add `TechnologyCollection`
- **technologydata/datapackage.py**: implement the full class. In particular:
   - removed the `name` attribute
   - set the `technologies` attribute as optional. The datapackage is in fact instantiated as 
   ```
   data_package = Datapackage("solar_photovoltaics_example_04")
   data_package.from_json(....)
   ```
   - set the `sources` attribute as optional. It is filled by means of the `get_source_collection` method starting from the `technologies` attribute
   - method `get_source_collection` generates the unique list of `Source` available in the `Technology` from the `technologies`. The lack of duplicates is enforced by means of a `set`. This forced me to override the `__eq__()` and `__hash__()` methods for the `Source` class (more details will follow later)
   - `from_json` loads the `technologies` attribute by means of the `TechnologyCollection.from_json` method. It populates the `sources` attributes by means of the `get_source_collection` method
   - methods `to_json` and `to_csv` make use of the corresponding methods from `TechnologyCollection` and `SourceCollection`
- **technologydata/technology_collection.py**: it implements the `TechnologyCollection` class, together with the requested methods `get` (which filters the `Technology` instances from the `TechnologyClass` based on the attribute values, `to_json` and `to_csv` that export respectively the collection to `json` (together with a schema file) and `csv` format and the `from_json`. This last method in particular deserves special attention. It reads the JSON data from the specified file and creates `Technology` objects for each item in the JSON list using `Technology.from_dict()`. In turns, `Technology.from_dict()` makes use of `Parameter.from_dict()`. Finally, I have also implemented `to_dataframe()`.
- **technologydata/parameter.py**: added the `from_dict` method to create an instance of the class from a dictionary. This is used  
- **technologydata/source.py**: I overrode the `__eq__()`, `__hash__()` and `__str__()` methods. All methods make use of non-None attributes.
- **technologydata/source_collection.py**: I overrode the `__iter__()`, `__str__()` and `__len__()` methods. The `__iter__()` method is used in particular in `get_source_collection` in the `Datapackage` class.


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is clearly stated.
- [ ] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the GPLv3 license.
