### PR TITLE
code: Allow parameter mul and div with scalars

### DIFF
--- a/src/technologydata/parameter.py
+++ b/src/technologydata/parameter.py
@@ -15,7 +15,7 @@ Examples
 """
 
 import logging
-from typing import Annotated, Any, Self
+from typing import Any, Self
 
 import pint
 from pydantic import BaseModel, Field, PrivateAttr

--- a/src/technologydata/parameter.py
+++ b/src/technologydata/parameter.py
@@ -15,7 +15,7 @@ Examples
 """
 
 import logging
-from typing import Any, Self
+from typing import Annotated, Any, Self
 
 import pint
 from pydantic import BaseModel, Field, PrivateAttr
@@ -59,25 +59,23 @@ class Parameter(BaseModel):  # type: ignore
 
     """
 
-    magnitude: typing.Annotated[
+    magnitude: Annotated[
         float, Field(description="The numerical value of the parameter.")
     ]
-    units: typing.Annotated[
-        str | None, Field(description="The unit of the parameter.")
-    ] = None
-    carrier: typing.Annotated[
+    units: Annotated[str | None, Field(description="The unit of the parameter.")] = None
+    carrier: Annotated[
         str | None,
         Field(description="Carriers of the units, e.g. 'H2', 'el', 'H2O'."),
     ] = None
-    heating_value: typing.Annotated[
+    heating_value: Annotated[
         str | None,
         Field(description="Heating value type for energy carriers ('LHV' or 'HHV')."),
     ] = None
-    provenance: typing.Annotated[
-        str | None, Field(description="The data's provenance.")
-    ] = None
-    note: typing.Annotated[str | None, Field(description="Additional notes.")] = None
-    sources: typing.Annotated[
+    provenance: Annotated[str | None, Field(description="The data's provenance.")] = (
+        None
+    )
+    note: Annotated[str | None, Field(description="Additional notes.")] = None
+    sources: Annotated[
         SourceCollection,
         Field(description="List of sources for this parameter."),
     ] = SourceCollection(sources=[])

--- a/src/technologydata/parameter.py
+++ b/src/technologydata/parameter.py
@@ -42,7 +42,7 @@ class Parameter(BaseModel):  # type: ignore
 
     Attributes
     ----------
-    magnitude : float
+    magnitude : int | float
         The numerical value of the parameter.
     units : Optional[str]
         The unit of the parameter.
@@ -60,7 +60,7 @@ class Parameter(BaseModel):  # type: ignore
     """
 
     magnitude: Annotated[
-        float, Field(description="The numerical value of the parameter.")
+        int | float, Field(description="The numerical value of the parameter.")
     ]
     units: Annotated[str | None, Field(description="The unit of the parameter.")] = None
     carrier: Annotated[
@@ -470,7 +470,7 @@ class Parameter(BaseModel):  # type: ignore
             ),
         )
 
-    def __truediv__(self, other: float | Self) -> Self:
+    def __truediv__(self, other: int | float | Self) -> Self:
         """
         Divide this Parameter by another Parameter.
 
@@ -495,7 +495,7 @@ class Parameter(BaseModel):  # type: ignore
         It also handles the division of carriers and heating values if present.
 
         """
-        if isinstance(other, float):
+        if isinstance(other, (int | float)):
             return Parameter(
                 magnitude=self.magnitude / other,
                 units=self.units,
@@ -539,13 +539,13 @@ class Parameter(BaseModel):  # type: ignore
             ),
         )
 
-    def __mul__(self, other: float | Self) -> Self:
+    def __mul__(self, other: int | float | Self) -> Self:
         """
         Multiply two Parameter instances.
 
         Parameters
         ----------
-        other : float | Parameter
+        other : int | float | Parameter
             A scalar or a Parameter instance to multiply with.
 
         Returns
@@ -567,7 +567,7 @@ class Parameter(BaseModel):  # type: ignore
         - Compatibility checks beyond heating values are not performed.
 
         """
-        if isinstance(other, float):
+        if isinstance(other, int | float):
             return Parameter(
                 magnitude=self.magnitude * other,
                 units=self.units,

--- a/src/technologydata/parameter.py
+++ b/src/technologydata/parameter.py
@@ -16,7 +16,7 @@ Examples
 
 import logging
 import typing
-from typing import Annotated
+from typing import Self
 
 import pint
 from pydantic import BaseModel, Field, PrivateAttr
@@ -60,23 +60,25 @@ class Parameter(BaseModel):  # type: ignore
 
     """
 
-    magnitude: Annotated[
+    magnitude: typing.Annotated[
         float, Field(description="The numerical value of the parameter.")
     ]
-    units: Annotated[str | None, Field(description="The unit of the parameter.")] = None
-    carrier: Annotated[
+    units: typing.Annotated[
+        str | None, Field(description="The unit of the parameter.")
+    ] = None
+    carrier: typing.Annotated[
         str | None,
         Field(description="Carriers of the units, e.g. 'H2', 'el', 'H2O'."),
     ] = None
-    heating_value: Annotated[
+    heating_value: typing.Annotated[
         str | None,
         Field(description="Heating value type for energy carriers ('LHV' or 'HHV')."),
     ] = None
-    provenance: Annotated[str | None, Field(description="The data's provenance.")] = (
-        None
-    )
-    note: Annotated[str | None, Field(description="Additional notes.")] = None
-    sources: Annotated[
+    provenance: typing.Annotated[
+        str | None, Field(description="The data's provenance.")
+    ] = None
+    note: typing.Annotated[str | None, Field(description="Additional notes.")] = None
+    sources: typing.Annotated[
         SourceCollection,
         Field(description="List of sources for this parameter."),
     ] = SourceCollection(sources=[])
@@ -471,14 +473,14 @@ class Parameter(BaseModel):  # type: ignore
             ),
         )
 
-    def __truediv__(self, other: "Parameter") -> "Parameter":
+    def __truediv__(self, other: float | Self) -> Self:
         """
         Divide this Parameter by another Parameter.
 
         Parameters
         ----------
-        other : Parameter
-            The Parameter instance to divide by.
+        other : float | Parameter
+            A scalar or a Parameter instance to divide by.
 
         Returns
         -------
@@ -496,6 +498,17 @@ class Parameter(BaseModel):  # type: ignore
         It also handles the division of carriers and heating values if present.
 
         """
+        if isinstance(other, float):
+            return Parameter(
+                magnitude=self.magnitude / other,
+                units=self.units,
+                carrier=self.carrier,
+                heating_value=self.heating_value,
+                provenance=self.provenance,
+                note=self.note,
+                sources=self.sources,
+            )
+
         # We don't check general compatibility here, as division is not a common operation for parameters.
         # Only ensure that the heating values are compatible.
         if self._pint_heating_value != other._pint_heating_value:
@@ -529,14 +542,14 @@ class Parameter(BaseModel):  # type: ignore
             ),
         )
 
-    def __mul__(self, other: "Parameter") -> "Parameter":
+    def __mul__(self, other: float | Self) -> Self:
         """
         Multiply two Parameter instances.
 
         Parameters
         ----------
-        other : Parameter
-            The other Parameter instance to multiply with.
+        other : float | Parameter
+            A scalar or a Parameter instance to multiply with.
 
         Returns
         -------
@@ -557,6 +570,17 @@ class Parameter(BaseModel):  # type: ignore
         - Compatibility checks beyond heating values are not performed.
 
         """
+        if isinstance(other, float):
+            return Parameter(
+                magnitude=self.magnitude * other,
+                units=self.units,
+                carrier=self.carrier,
+                heating_value=self.heating_value,
+                provenance=self.provenance,
+                note=self.note,
+                sources=self.sources,
+            )
+
         # We don't check general compatibility here, as multiplication is not a common operation for parameters.
         # Only ensure that the heating values are compatible.
         if self._pint_heating_value != other._pint_heating_value:

--- a/test/test_parameter.py
+++ b/test/test_parameter.py
@@ -540,6 +540,24 @@ class TestParameter:
         """Test that the fixture example_parameter yields a parameter object."""
         assert isinstance(example_parameter, technologydata.Parameter)
 
+    def test_parameter_mul_scalar(self) -> None:
+        """Test multiplication of a Parameter by a scalar."""
+        factor = 3
+        param = technologydata.Parameter(magnitude=2, units="kW")
+        result = param * factor
+        assert isinstance(result, technologydata.Parameter)
+        assert result.magnitude == param.magnitude * factor
+        assert result.units == param.units
+
+    def test_parameter_div_scalar(self) -> None:
+        """Test division of a Parameter by a scalar."""
+        divisor = 3
+        param = technologydata.Parameter(magnitude=6, units="kW")
+        result = param / divisor
+        assert isinstance(result, technologydata.Parameter)
+        assert result.magnitude == param.magnitude / divisor
+        assert result.units == param.units
+
     def test_parameter_pow_basic(self) -> None:
         """Test integer exponentiation."""
         param = technologydata.Parameter(magnitude=2, units="kW")

--- a/test/test_parameter.py
+++ b/test/test_parameter.py
@@ -542,7 +542,15 @@ class TestParameter:
 
     def test_parameter_mul_scalar(self) -> None:
         """Test multiplication of a Parameter by a scalar."""
-        factor = 3
+        factor = 3.0
+        param = technologydata.Parameter(magnitude=2, units="kW")
+        result = param * factor
+        assert isinstance(result, technologydata.Parameter)
+        assert result.magnitude == param.magnitude * factor
+        assert result.units == param.units
+
+        # Test multiplication by an integer
+        factor = int(3.0)
         param = technologydata.Parameter(magnitude=2, units="kW")
         result = param * factor
         assert isinstance(result, technologydata.Parameter)
@@ -551,7 +559,16 @@ class TestParameter:
 
     def test_parameter_div_scalar(self) -> None:
         """Test division of a Parameter by a scalar."""
-        divisor = 3
+        # Test division by an float
+        divisor = 3.0
+        param = technologydata.Parameter(magnitude=6, units="kW")
+        result = param / divisor
+        assert isinstance(result, technologydata.Parameter)
+        assert result.magnitude == param.magnitude / divisor
+        assert result.units == param.units
+
+        # Test division by an integer
+        divisor = int(3.0)
         param = technologydata.Parameter(magnitude=6, units="kW")
         result = param / divisor
         assert isinstance(result, technologydata.Parameter)


### PR DESCRIPTION
Up until now, parameters always had to be divided / multiplied by other parameters. This allows for scalar operations on them.
