### PR TITLE
Turn Source.store_in_wayback into a private method

### DIFF
--- a/docs/user_guide/class-diagram.puml
+++ b/docs/user_guide/class-diagram.puml
@@ -14,7 +14,7 @@ class Source {
   - url_date_archive: str
 
   + ensure_in_wayback()
-  + store_in_wayback()
+  + _store_in_wayback()
   + retrieve_from_wayback()
   + _get_save_path()
   + _get_content_type()
@@ -24,7 +24,7 @@ class Source {
   + __str__(other)
 }
 
-note right of Source::store_in_wayback
+note right of Source::_store_in_wayback
   Stores the source in the Internet Archive's Wayback Machine,
   to keep it accessible in the future.
 end note

--- a/src/technologydata/source.py
+++ b/src/technologydata/source.py
@@ -8,7 +8,7 @@ Source class for representing bibliographic and web sources, with archiving supp
 Examples
 --------
 >>> src = Source(title="Example Source", authors="The Authors")
->>> src.store_in_wayback()
+>>> src._store_in_wayback()
 >>> src.retrieve_from_wayback()
 
 """
@@ -172,7 +172,7 @@ class Source(pydantic.BaseModel):  # type: ignore
             )
 
         if self.url_archive is None and self.url_date_archive is None:
-            archived_info = self.store_in_wayback(self.url)
+            archived_info = self._store_in_wayback(self.url)
             if archived_info is not None:
                 archived_url, new_capture_flag, timestamp = archived_info
                 if new_capture_flag:
@@ -187,7 +187,7 @@ class Source(pydantic.BaseModel):  # type: ignore
                 self.url_archive = archived_url
 
     @staticmethod
-    def store_in_wayback(
+    def _store_in_wayback(
         url_to_archive: str,
     ) -> tuple[Any, bool | None, str | None] | None:
         """
@@ -215,7 +215,7 @@ class Source(pydantic.BaseModel):  # type: ignore
         --------
         >>> from technologydata import Source
         >>> some_url = "some_url"
-        >>> archived_info = Source.store_in_wayback(some_url)
+        >>> archived_info = Source._store_in_wayback(some_url)
 
         """
         archive_url = savepagenow.capture_or_cache(url_to_archive)

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -158,7 +158,7 @@ class TestSource:
         url_to_archive = (
             "https://www.engineeringtoolbox.com/co2-emission-fuels-d_1085.html"
         )
-        archived_info = technologydata.Source.store_in_wayback(url_to_archive)
+        archived_info = technologydata.Source._store_in_wayback(url_to_archive)
 
         # Check if archived_info is None
         assert archived_info is not None, "archived_info should not be None"


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
`Source.store_in_wayback` is only used as part of `Source.ensure_in_wayback`. It should be therefore turned into a private method and not exposed.

This is also safer, because `Source.ensure_in_wayback` (unlike `store_in_wayback`) checks whether the source is already stored on the wayback machine.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is clearly stated.
- [ ] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the GPLv3 license.
