### PR TITLE
Skip three more unit tests

### DIFF
--- a/test/test_source.py
+++ b/test/test_source.py
@@ -196,6 +196,7 @@ class TestSource:
         assert example_source.url_date_archive is not None
         assert example_source.url_archive is not None
 
+    @pytest.mark.webarchive  # type: ignore
     @pytest.mark.parametrize(
         "url_archived, source_path, source_title, expected_path",
         [

--- a/test/test_source_collection.py
+++ b/test/test_source_collection.py
@@ -81,6 +81,7 @@ class TestSourceCollection:
         assert example_source_collection.sources[0].authors == "Author 1"
         assert example_source_collection.sources[1].authors == "Author 2"
 
+    @pytest.mark.webarchive  # type: ignore
     @pytest.mark.parametrize(
         "example_source_collection",
         [


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Due to the fact that three more unit tests related to the wayback machine are failing, I have introduced in this PR the fact that they get skipped by default when running `pytest`.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Data source for new technologies is clearly stated.
- [ ] Newly introduced dependencies are added to `environment.yaml` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the GPLv3 license.
